### PR TITLE
make some functions public

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "retry",
+    .name = .retry,
     .version = "0.1.0",
+    .fingerprint = 0x2ee051e37d9cc5a8,
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/root.zig
+++ b/src/root.zig
@@ -74,7 +74,7 @@ pub const Backoff = union(enum) {
         policy: Policy,
         backoff: Backoff,
         current: f64 = 1,
-        fn next(self: *@This()) ?usize {
+        pub fn next(self: *@This()) ?usize {
             if ((self.policy.max_retries orelse 1) > 0) {
                 const factor: f64 = switch (self.backoff) {
                     .fixed_delay => self.current,

--- a/src/root.zig
+++ b/src/root.zig
@@ -58,11 +58,11 @@ pub const Backoff = union(enum) {
     fixed_delay: void,
     exponential_delay: f64,
 
-    fn fixed() @This() {
+    pub fn fixed() @This() {
         return .{ .fixed_delay = {} };
     }
 
-    fn exponential(exponent: f64) @This() {
+    pub fn exponential(exponent: f64) @This() {
         return .{ .exponential_delay = exponent };
     }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -139,7 +139,7 @@ pub const Policy = struct {
     }
 
     /// Conventice for common configuration. Returns a new Policy with defaults with an exponential delay
-    fn exponential(delay: usize, exponent: f64) @This() {
+    pub fn exponential(delay: usize, exponent: f64) @This() {
         return .{
             .backoff = Backoff.exponential(exponent),
             .delay = delay,


### PR DESCRIPTION
Since `Backoff.Iterator` is public, I think its `next()` should be as well. I ran into this because I needed it.

Looks like `Policy.exponential()` and the `Backoff` convenience constructors were simply forgotten to be marked `pub`.

Depends on #2 because Zig 0.14 was released since I opened this PR.